### PR TITLE
patches not stores

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/ClientCounterManager.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/ClientCounterManager.kt
@@ -32,5 +32,22 @@ class ClientCounterManager(
             if (data !is ClientCounterManager) return
             CounterModClient.clientCounterData = data
         }
+
+        fun runActionIncremental(data: ClientInstancedPlayerData) {
+            val clientData = CounterModClient.clientCounterData
+
+            if (data !is ClientCounterManager) return
+            for ((counterType, counter) in data.counters.entries) {
+                val targetClientCounter = clientData.counters[counterType]
+                    ?: throw Error("Unregistered counter type sent by server ${counterType.type}")
+                for ((speciesId, speciesRecord) in counter.count) {
+                    val clientSpeciesRecord = targetClientCounter.count.getOrPut(speciesId, ::mutableMapOf)
+                    for ((formName, count) in speciesRecord) {
+                        clientSpeciesRecord[formName] = count
+                    }
+                }
+                targetClientCounter.streak = counter.streak
+            }
+        }
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/Counter.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/Counter.kt
@@ -12,7 +12,7 @@ import us.timinc.mc.cobblemon.counter.CounterMod
 
 class Counter(
     val count: MutableMap<ResourceLocation, MutableMap<String, Int>> = mutableMapOf(),
-    val streak: Streak = Streak(),
+    var streak: Streak = Streak(),
 ) {
     companion object {
         val CODEC: Codec<Counter> = RecordCodecBuilder.create { instance ->

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CounterManager.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CounterManager.kt
@@ -42,10 +42,23 @@ class CounterManager(
         speciesRecord[formName] = speciesRecord.getOrDefault(formName, 0) + 1
         counter.streak.add(speciesId, formName, CounterMod.config.breakStreakOnForm.contains(counterType.type))
 
-        uuid.getPlayer()?.sendPacket(
+        val player = uuid.getPlayer() ?: return
+
+        val patchData = ClientCounterManager(
+            mutableMapOf(
+                counterType to Counter(
+                    mutableMapOf(
+                        speciesId to mutableMapOf(formName to speciesRecord[formName]!!)
+                    ),
+                    counter.streak
+                )
+            )
+        )
+
+        player.sendPacket(
             SetClientPlayerDataPacket(
                 type = PlayerInstancedDataStores.COUNTER,
-                playerData = toClientData(),
+                playerData = patchData,
                 isIncremental = true
             )
         )

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/storage/PlayerInstancedDataStores.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/storage/PlayerInstancedDataStores.kt
@@ -11,7 +11,7 @@ object PlayerInstancedDataStores {
             CounterMod.modResource("counter"),
             ClientCounterManager::decode,
             ClientCounterManager::runAction,
-            ClientCounterManager::runAction
+            ClientCounterManager::runActionIncremental
         )
     )
 }


### PR DESCRIPTION
on incremental update to client, send a ClientCounterManager instance with only the modified data in it. patch into local data on client, instead of replacing all data every time.
