### PR TITLE
fixed duplicate names in every item's tooltips

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/item/CounterTooltipGenerator.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/item/CounterTooltipGenerator.kt
@@ -9,11 +9,11 @@ import us.timinc.mc.cobblemon.counter.api.CounterType
 
 object CounterTooltipGenerator : TooltipGenerator() {
     override fun generateTooltip(stack: ItemStack, lines: MutableList<Component>): MutableList<Component> {
+        val resultLines = mutableListOf<Component>()
         if (!stack.`is`(CounterItems.COUNTER)) {
-            return lines
+            return resultLines
         }
 
-        val resultLines = mutableListOf<Component>()
         val mode = if (CounterItem.CLIENT_SPECIES === null) "streak" else "count"
         resultLines.add(Component.translatable("cobbled_counter.item.counter.tooltip.$mode"))
         CounterType.entries.forEach {
@@ -54,12 +54,12 @@ object CounterTooltipGenerator : TooltipGenerator() {
     }
 
     override fun generateAdditionalTooltip(stack: ItemStack, lines: MutableList<Component>): MutableList<Component> {
+        val resultLines = mutableListOf<Component>()
         if (!stack.`is`(CounterItems.COUNTER)) {
-            return lines
+            return resultLines
         }
 
         val otherMode = if (CounterItem.CLIENT_SPECIES === null) "count" else "streak"
-        val resultLines = mutableListOf<Component>()
         resultLines.add(Component.translatable("cobbled_counter.item.counter.tooltip.switch_mode_info.to_$otherMode"))
         return resultLines
     }


### PR DESCRIPTION
why is this even possible? why aren't we modifying a list and passing it down the line? why is the title part of the tooltip list we receive that's apparently not meant to be used at all? I'm not mad.
